### PR TITLE
fix :: 스크롤 오버플로우 코드 수정

### DIFF
--- a/src/components/home/myInfo/style.ts
+++ b/src/components/home/myInfo/style.ts
@@ -68,7 +68,7 @@ export const MyInfoListWrap = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
-  overflow: scroll;
+  overflow: auto;
 
   ::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
일부 브라우저에서 오버플로우 속성이 다른 문제를 해결

##### **📘 한 내용**

Firefox 브라우저에서 overflow 스타일에 문제가 발생했습니다

문제 발생 사진
<img width="401" alt="Screenshot 2024-06-05 at 12 14 04 PM" src="https://github.com/Team-B1ND/dodamdodam-web/assets/89149734/a980c948-1f7d-41c7-8a0a-e8835be9775c">

이 문제를 `overflow: scroll;` > `overflow: auto;` 로 변경하여 문제를 해결하였습니다

문제 해결 사진
<img width="417" alt="Screenshot 2024-06-05 at 12 15 39 PM" src="https://github.com/Team-B1ND/dodamdodam-web/assets/89149734/8c44c6aa-8657-4a85-a329-a390389d095d">


---
